### PR TITLE
README.md: add mission statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,9 @@ Our mission is to foster a robust Rust cryptography ecosystem:
 - Provide overall direction for cryptography in Rust by forstering collaboration on an interoperable cryptographic ecosystem
 - Act as a resource for answering questions about the use of cryptography in Rust projects
 
+Note that this is a new group and figuring out its exact purpose is a work-in-progress.
+As we figure out a governance process we will be revising our mission statement and
+hopefully publishing a [vision document].
+
 [issue tracker]: https://github.com/The-DevX-Initiative/RCIG_Coordination_Repo/issues
+[vision document]: https://github.com/The-DevX-Initiative/RCIG_Coordination_Repo/issues/4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# RCIG_Coordination_Repo
+# Rust Cryptography Interest Group (RCIG) Coordination Repo
+
+This repository is the central [issue tracker] used by the RCIG in order to
+coordinate efforts towards promoting cryptography in Rust.
+
+## Mission
+Our mission is to foster a robust Rust cryptography ecosystem:
+
+- Create a focal point for discussion and work on Rust cryptography in general
+- Provide overall direction for cryptography in Rust by forstering collaboration on an interoperable cryptographic ecosystem
+- Act as a resource for answering questions about the use of cryptography in Rust projects
+
+[issue tracker]: https://github.com/The-DevX-Initiative/RCIG_Coordination_Repo/issues


### PR DESCRIPTION
[Rendered](https://github.com/The-DevX-Initiative/RCIG_Coordination_Repo/blob/309674d11ca476043a406ef16e8247cd5981ab70/README.md)

This is adapted from the mission statement I originally wrote as part of a Cryptography WG application:

https://github.com/rust-lang/wg-governance/issues/12#issuecomment-534161618

We haven't yet figured out governance, so perhaps this is a bit premature, but this repo is otherwise empty so this seems nice to have.

I think once we do figure out governance, then whatever governance process we come up with can revise this statement, but in the meantime having something seems nice.