### PR TITLE
Suggest adding Themis into high-level libs

### DIFF
--- a/Awesome_Rust_Cryptography.md
+++ b/Awesome_Rust_Cryptography.md
@@ -34,8 +34,6 @@ These libraries function at a very high level and are designed for simplicity an
 
 - [tink-rust](https://github.com/project-oak/tink-rust) Rust port of Google's high-level Tink cryptography library.
 
-- [themis](https://github.com/cossacklabs/themis) Cross-platform general purpose crypto library for securing data during authentication, storage, messaging, network exchange, etc.
-
 
 ## Transport Encryption Libraries
 
@@ -67,6 +65,8 @@ contained within a single library.
   focused on the implementation, testing, and optimization of a core set of cryptographic operations exposed via an easy-to-use (and hard-to-misuse) API. *ring* exposes a Rust API and is written in a hybrid of Rust, C, and assembly language.
 
 - [sodiumoxide](https://github.com/sodiumoxide/sodiumoxide) Type-safe efficient Rust bindings to [libsodium](https://libsodium.org).
+
+- [themis](https://github.com/cossacklabs/themis) Cross-platform general purpose crypto library for securing data during authentication, storage, messaging, network exchange, etc.
 
 
 ## Traits for Cryptographic Primitives

--- a/Awesome_Rust_Cryptography.md
+++ b/Awesome_Rust_Cryptography.md
@@ -34,6 +34,8 @@ These libraries function at a very high level and are designed for simplicity an
 
 - [tink-rust](https://github.com/project-oak/tink-rust) Rust port of Google's high-level Tink cryptography library.
 
+- [themis](https://github.com/cossacklabs/themis) Cross-platform general purpose crypto library for securing data during authentication, storage, messaging, network exchange, etc.
+
 
 ## Transport Encryption Libraries
 


### PR DESCRIPTION
Would you be interested in adding [Themis](https://github.com/cossacklabs/themis)?

That's a general purpose lib, 6yo, with rust-themis wrapper. C core (stable), multiple wrappers supported by the same team, so 100% compatible, [tons of docs and examples](https://docs.cossacklabs.com/themis/). 

Rust wrapper was added by @ilammy ~2.5 yrs ago and stable since then. [Docs](https://docs.cossacklabs.com/themis/languages/rust/), [crate](https://crates.io/crates/themis).

Under the hood Themis uses OpenSSL/BoringSSL/LibreSSL, etc, and provides crypto-systems for popular use cases – secure cell for aead (similar to libsodium's secure box); secure comparator for zkp-based authN; secure message for sending messages to peers (ecdh+aead).