### PR TITLE
Awesome Rust Cryptography: re-add `phpass` crate

### DIFF
--- a/Awesome_Rust_Cryptography.md
+++ b/Awesome_Rust_Cryptography.md
@@ -289,6 +289,9 @@ use.
  Pure Rust implementation of the Password-Based Key Derivation Function v2
  (PBKDF2).
 
+- [phpass](https://github.com/clausehound/phpass)
+  Pure Rust implementation of the PhPass algorithm used by WordPress.
+
 - [pkcs5](https://github.com/RustCrypto/utils/tree/master/pkcs5) Pure Rust
  implementation of Public-Key Cryptography Standards #5: Password-Based
  Cryptography Specification Version 2.1 (RFC 8018) with support for the scrypt


### PR DESCRIPTION
It was added to the generated HTML by mistake in #43, which was subsequently removed in #48.

The Markdown file is the proper place to add it.