### PR TITLE
add RCIG mascot to Awesome Rust Cryptography markdown

### DIFF
--- a/Awesome_Rust_Cryptography.md
+++ b/Awesome_Rust_Cryptography.md
@@ -2,6 +2,7 @@
 
 <img align="right" height="100px" src="https://raw.githubusercontent.com/The-DevX-Initiative/RCIG_Coordination_Repo/main/mascot.png">
 
+<img align="right" height="100px" src="https://raw.githubusercontent.com/The-DevX-Initiative/RCIG_Coordination_Repo/main/RCIG_Mascot3.png">
 Below is a list of actively maintained, high-quality cryptography libraries
 independently developed by members of the Rust Community.
 


### PR DESCRIPTION
I added RCIG Mascot to the Cryptography.rs markdown template. I have spoken with @tarcieri, and it's all good to be merged. 